### PR TITLE
Add promise to close channel

### DIFF
--- a/src/__tests__/QWrapperDomain.test.ts
+++ b/src/__tests__/QWrapperDomain.test.ts
@@ -33,3 +33,31 @@ test('Queue manager constructor object connectionUrl', (done) => {
   const qManager = new QWrapperDomain(settings);
   done();
 });
+
+import * as amqp from 'amqplib/callback_api';
+test('Close returns a promise', async () => {
+  const settings: QWrapperSettings = {
+    exchange: 'dsd_exchange',
+    connection: {
+      protocol: 'amqp',
+      hostname: 'localhost',
+      port: 5672,
+      username: 'guest',
+      password: 'guest',
+      locale: 'en_US',
+      frameMax: 0,
+      heartbeat: 0,
+      vhost: '/',
+    },
+    queue:'dsd_queue',
+    dleQueue: 'dsd_dead_letter',
+    exchangeType: 'fanout'
+  };
+
+  const qManager = new QWrapperDomain(settings);
+  await qManager.initialize();
+  expect(qManager['_channel']).toBeDefined();
+  await qManager.close();
+  expect(qManager['_channel']).toBeUndefined();
+  await new Promise(res => (qManager['_connection'] as any).close(res));
+});

--- a/src/__tests__/QWrapperDomain.test.ts
+++ b/src/__tests__/QWrapperDomain.test.ts
@@ -1,58 +1,37 @@
 import {QWrapperDomain, QWrapperSettings} from '..';
 
+const settings: QWrapperSettings = {
+  exchange: 'test_dsd_exchange',
+  connection: {
+    protocol: 'amqp',
+    hostname: 'localhost',
+    port: 5672,
+    username: 'guest',
+    password: 'guest',
+    locale: 'en_US',
+    frameMax: 0,
+    heartbeat: 0,
+    vhost: '/',
+  },
+  queue:'test_dsd_queue',
+  dleQueue: 'test_dsd_dead_letter',
+  exchangeType: 'fanout'
+};
+
 test('Queue manager constructor string url', (done) => {
   const qw = new QWrapperDomain({
-    exchange: 'dsd_exchange',
+    ...settings,
     connection: 'amqp://localhost',
-    queue:'dsd_queue',
-    dleQueue: 'dsd_dead_letter',
-    exchangeType: 'direct'
   });
   done()
 });
 
 test('Queue manager constructor object connectionUrl', (done) => {
-  const settings: QWrapperSettings = {
-    exchange: 'dsd_exchange',
-    connection: {
-      protocol: 'amqp',
-      hostname: 'localhost',
-      port: 5672,
-      username: 'bob',
-      password: 'bobspassword',
-      locale: 'en_US',
-      frameMax: 0,
-      heartbeat: 0,
-      vhost: '/',
-    },
-    queue:'dsd_queue',
-    dleQueue: 'dsd_dead_letter',
-    exchangeType: 'fanout'
-  };
-
   const qManager = new QWrapperDomain(settings);
   done();
 });
 
 test('Close channel returns a promise', async () => {
-  const settings: QWrapperSettings = {
-    exchange: 'dsd_exchange',
-    connection: {
-      protocol: 'amqp',
-      hostname: 'localhost',
-      port: 5672,
-      username: 'guest',
-      password: 'guest',
-      locale: 'en_US',
-      frameMax: 0,
-      heartbeat: 0,
-      vhost: '/',
-    },
-    queue:'dsd_queue',
-    dleQueue: 'dsd_dead_letter',
-    exchangeType: 'fanout'
-  };
-
   const qManager = new QWrapperDomain(settings);
   await qManager.initialize();
   expect(qManager['_channel']).toBeDefined();
@@ -62,24 +41,6 @@ test('Close channel returns a promise', async () => {
 });
 
 test('Close connection returns a promise', async () => {
-  const settings: QWrapperSettings = {
-    exchange: 'dsd_exchange',
-    connection: {
-      protocol: 'amqp',
-      hostname: 'localhost',
-      port: 5672,
-      username: 'guest',
-      password: 'guest',
-      locale: 'en_US',
-      frameMax: 0,
-      heartbeat: 0,
-      vhost: '/',
-    },
-    queue:'dsd_queue',
-    dleQueue: 'dsd_dead_letter',
-    exchangeType: 'fanout'
-  };
-
   const qManager = new QWrapperDomain(settings);
   await qManager.initialize();
   expect(qManager['_channel']).toBeDefined();

--- a/src/__tests__/QWrapperDomain.test.ts
+++ b/src/__tests__/QWrapperDomain.test.ts
@@ -34,8 +34,7 @@ test('Queue manager constructor object connectionUrl', (done) => {
   done();
 });
 
-import * as amqp from 'amqplib/callback_api';
-test('Close returns a promise', async () => {
+test('Close channel returns a promise', async () => {
   const settings: QWrapperSettings = {
     exchange: 'dsd_exchange',
     connection: {
@@ -59,5 +58,32 @@ test('Close returns a promise', async () => {
   expect(qManager['_channel']).toBeDefined();
   await qManager.close();
   expect(qManager['_channel']).toBeUndefined();
-  await new Promise(res => (qManager['_connection'] as any).close(res));
+  await qManager.closeConnection();
+});
+
+test('Close connection returns a promise', async () => {
+  const settings: QWrapperSettings = {
+    exchange: 'dsd_exchange',
+    connection: {
+      protocol: 'amqp',
+      hostname: 'localhost',
+      port: 5672,
+      username: 'guest',
+      password: 'guest',
+      locale: 'en_US',
+      frameMax: 0,
+      heartbeat: 0,
+      vhost: '/',
+    },
+    queue:'dsd_queue',
+    dleQueue: 'dsd_dead_letter',
+    exchangeType: 'fanout'
+  };
+
+  const qManager = new QWrapperDomain(settings);
+  await qManager.initialize();
+  expect(qManager['_channel']).toBeDefined();
+  await qManager.closeConnection();
+  expect(qManager['_channel']).toBeUndefined();
+  expect(qManager['_connection']).toBeUndefined();
 });

--- a/src/domains/QWrapperDomain.ts
+++ b/src/domains/QWrapperDomain.ts
@@ -101,15 +101,32 @@ export class QWrapperDomain {
 
   public close (): Promise<void> {
     return new Promise((resolve) => {
-      if (this._channel) {
-        this._channel.close(() => {
-          console.info('Channel closed');
-          this._channel = undefined;
-          return resolve();
-        });
-      } else {
+      if (!this._channel) {
         return resolve();
       }
+      this._channel.close(() => {
+        console.info('Channel closed');
+        this._channel = undefined;
+        return resolve();
+      });
+    });
+  }
+  
+  public closeConnection (): Promise<any> {
+    return new Promise(async (resolve, reject) => {
+      await this.close();
+
+      if (!this._connection) {
+        return resolve();
+      }
+      this._connection.close((err?: any) => {
+        if (err) {
+          return reject(err);
+        }
+        console.info('Connection closed');
+        this._connection = undefined;
+        return resolve();
+      });
     });
   }
 

--- a/src/domains/QWrapperDomain.ts
+++ b/src/domains/QWrapperDomain.ts
@@ -6,6 +6,7 @@ export class QWrapperDomain {
 
   private _settings: QWrapperSettings;
   private _channel: amqp.Channel | undefined;
+  private _connection: amqp.Connection | undefined;
 
   constructor (settings: QWrapperSettings) {
     this._settings = settings;
@@ -19,7 +20,9 @@ export class QWrapperDomain {
           throw error0;
         }
 
-        connection.createChannel((error1, channel) => {
+        this._connection = connection;
+
+        this._connection.createChannel((error1, channel) => {
           if (error1) {
             console.error('Error creating channel... ', error1);
             throw error1;
@@ -96,12 +99,18 @@ export class QWrapperDomain {
     return this.consume(callback, true);
   }
 
-  public close (): void {
-    if (this._channel) {
-      this._channel.close(() => {
-        console.info('Channel closed');
-      });
-    }
+  public close (): Promise<void> {
+    return new Promise((resolve) => {
+      if (this._channel) {
+        this._channel.close(() => {
+          console.info('Channel closed');
+          this._channel = undefined;
+          return resolve();
+        });
+      } else {
+        return resolve();
+      }
+    });
   }
 
   private sendResponseToChannel (consumerResponse: ConsumerResponse, channel: Channel, message: amqMessage) {


### PR DESCRIPTION
When testing, it's useful to have a promise returned from any close actions

The same logic could be used for `_connection`. In order to prevent tests from hanging on completion, we needed to expose this connection.