### PR TITLE
[FEAT] Allow sending messages to DLE with modified payload

### DIFF
--- a/src/domains/QWrapperDomain.ts
+++ b/src/domains/QWrapperDomain.ts
@@ -155,7 +155,7 @@ export class QWrapperDomain {
     this.logVerbose('sendResponseToChannel called');
     channel.ack(message);
     if (!consumerResponse.processed) {
-      this?._channel?.sendToQueue?.(this._settings.dleQueue, message.content);
+      channel.sendToQueue(this._settings.dleQueue, message.content);
     }
   }
 }

--- a/src/domains/QWrapperDomain.ts
+++ b/src/domains/QWrapperDomain.ts
@@ -153,10 +153,9 @@ export class QWrapperDomain {
 
   private sendResponseToChannel (consumerResponse: ConsumerResponse, channel: Channel, message: amqMessage) {
     this.logVerbose('sendResponseToChannel called');
-    if (consumerResponse.processed) {
-      channel.ack(message);
-    } else {
-      channel.reject(message, consumerResponse.requeue);
+    channel.ack(message);
+    if (!consumerResponse.processed) {
+      this?._channel?.sendToQueue?.(this._settings.dleQueue, message.content);
     }
   }
 }


### PR DESCRIPTION
Looked online for a solution for modifying the message before sending to DLE, but I don't believe it's possible.

[some SO post for inspiration](https://stackoverflow.com/questions/42058404/rabbitmq-can-consumer-persist-message-change-before-nack)
[the reject call in amqplib which does not pass the message through](https://github.com/squaremo/amqp.node/blob/master/lib/callback_model.js#L257)

Since we cannot reject or nack with a modified payload, instead we can always ack and just check the processed variable to see if it failed.

Since the message is passed to the consumer by reference, we can just javascript the content and re-send to DLE manually.

Eg:
```typescript
import { Message } from 'amqplib/callback_api';
import { ConsumerResponse } from 'q-wrapper';

interface Content {
  taskId: string;
  error?: any;
  requeueCount?: number;
}

export const consumerCallback = async (msg: Message): Promise<ConsumerResponse> => {
  const response: ConsumerResponse = {
    processed: false,
    requeue: false,
  };

  let data: Content = { taskId: null };
  try {
    data = JSON.parse(msg.content.toString('utf8'));

    await SomethingThatThrows();

    response.processed = true;
  } catch (error) {
    console.error('[consumerCallback]: error consuming message');
    console.error(error);

    data.error = { message: error.message, stack: error.stack };
    data.requeueCount = (data.requeueCount ?? -1) + 1;
    msg.content = Buffer.from(JSON.stringify(data));
  }

  return response;
};
```