### PR TITLE
Allow using of different DLE exchange

### DIFF
--- a/src/__tests__/QWrapperDomain.test.ts
+++ b/src/__tests__/QWrapperDomain.test.ts
@@ -1,4 +1,4 @@
-import {QWrapperDomain, QWrapperSettings} from '..';
+import { QWrapperDomain, QWrapperSettings } from '..';
 
 const settings: QWrapperSettings = {
   exchange: 'test_dsd_exchange',
@@ -14,9 +14,10 @@ const settings: QWrapperSettings = {
     vhost: '/',
   },
   queue:'test_dsd_queue',
-  dleQueue: 'test_dsd_dead_letter',
   exchangeType: 'fanout',
-  reconnect: false
+  reconnect: false,
+  dleExchange: 'test_dsd_dead_exchange',
+  dleQueue: 'test_dsd_dead_letter',
 };
 
 test('Queue manager constructor string url', (done) => {

--- a/src/domains/QWrapperDomain.ts
+++ b/src/domains/QWrapperDomain.ts
@@ -6,7 +6,6 @@ import { inspect } from 'util';
 const packageName = 'q-wrapper: ';
 
 export class QWrapperDomain {
-
   private _verboseLogging: boolean = false;
   private _veryVerboseLogging: boolean = false;
 
@@ -18,7 +17,7 @@ export class QWrapperDomain {
     this._settings = settings;
   }
 
-  logVerbose (key: string, toLog?: any) {
+  logVerbose (key: string, toLog?: any): void {
     if (this._verboseLogging) {
       console.log(packageName + ' ' + key);
       if (toLog) {
@@ -27,13 +26,13 @@ export class QWrapperDomain {
     }
   }
 
-  logVeryVerbose (toLog?: any) {
+  logVeryVerbose (toLog?: any): void {
     if (this._veryVerboseLogging) {
       console.log(packageName, inspect(toLog, false, null, true /* enable colors */));
     }
   }
 
-  setLoggingLevels () {
+  setLoggingLevels (): void {
     this._verboseLogging = this._settings.verboseLogging || false;
     this._veryVerboseLogging = this._settings.veryVerboseLogging || false;
     if (process.env.q_wrapper_verbose_logging && process.env.q_wrapper_verbose_logging.toLowerCase() === 'true') {
@@ -72,14 +71,16 @@ export class QWrapperDomain {
           this._channel.assertExchange(this._settings.exchange, this._settings.exchangeType, durable);
           console.info(`${packageName} Exchange: '${this._settings.exchange}' asserted successfully`);
 
+          this._channel.assertExchange(this._settings.dleExchange, 'direct', durable);
+          console.info(`${packageName} Exchange: '${this._settings.dleExchange}' asserted successfully`);
+
           this._channel.assertQueue(this._settings.dleQueue, durable);
           console.info(`${packageName} DLE Queue: '${this._settings.dleQueue}' asserted successfully`);
-
-          this._channel.bindQueue(this._settings.dleQueue, this._settings.exchange, this._settings.dleQueue);
+          this._channel.bindQueue(this._settings.dleQueue, this._settings.dleExchange, this._settings.dleQueue);
 
           this._channel.assertQueue(this._settings.queue, {
             durable: true,
-            deadLetterExchange: this._settings.exchange,
+            deadLetterExchange: this._settings.dleExchange,
             deadLetterRoutingKey: this._settings.dleQueue
           });
           console.info(`${packageName} Queue: '${this._settings.queue}' asserted successfully`);
@@ -181,7 +182,7 @@ export class QWrapperDomain {
   }
 
   public closeConnection (): Promise<any> {
-    return new Promise(async (resolve, reject) => {
+    return new Promise<void>(async (resolve, reject) => {
       await this.close();
 
       if (!this._connection) {

--- a/src/domains/QWrapperDomain.ts
+++ b/src/domains/QWrapperDomain.ts
@@ -71,18 +71,19 @@ export class QWrapperDomain {
           this._channel.assertExchange(this._settings.exchange, this._settings.exchangeType, durable);
           console.info(`${packageName} Exchange: '${this._settings.exchange}' asserted successfully`);
 
-          if (this._settings.dleExchange !== this._settings.exchange) {
-            this._channel.assertExchange(this._settings.dleExchange, 'direct', durable);
-            console.info(`${packageName} Exchange: '${this._settings.dleExchange}' asserted successfully`);
+          const dleExchange = this._settings.dleExchange || this._settings.exchange;
+          if (dleExchange !== this._settings.exchange) {
+            this._channel.assertExchange(dleExchange, 'direct', durable);
+            console.info(`${packageName} Exchange: '${dleExchange}' asserted successfully`);
           }
 
           this._channel.assertQueue(this._settings.dleQueue, durable);
           console.info(`${packageName} DLE Queue: '${this._settings.dleQueue}' asserted successfully`);
-          this._channel.bindQueue(this._settings.dleQueue, this._settings.dleExchange, this._settings.dleQueue);
+          this._channel.bindQueue(this._settings.dleQueue, dleExchange, this._settings.dleQueue);
 
           this._channel.assertQueue(this._settings.queue, {
             durable: true,
-            deadLetterExchange: this._settings.dleExchange,
+            deadLetterExchange: dleExchange,
             deadLetterRoutingKey: this._settings.dleQueue
           });
           console.info(`${packageName} Queue: '${this._settings.queue}' asserted successfully`);

--- a/src/domains/QWrapperDomain.ts
+++ b/src/domains/QWrapperDomain.ts
@@ -71,8 +71,10 @@ export class QWrapperDomain {
           this._channel.assertExchange(this._settings.exchange, this._settings.exchangeType, durable);
           console.info(`${packageName} Exchange: '${this._settings.exchange}' asserted successfully`);
 
-          this._channel.assertExchange(this._settings.dleExchange, 'direct', durable);
-          console.info(`${packageName} Exchange: '${this._settings.dleExchange}' asserted successfully`);
+          if (this._settings.dleExchange !== this._settings.exchange) {
+            this._channel.assertExchange(this._settings.dleExchange, 'direct', durable);
+            console.info(`${packageName} Exchange: '${this._settings.dleExchange}' asserted successfully`);
+          }
 
           this._channel.assertQueue(this._settings.dleQueue, durable);
           console.info(`${packageName} DLE Queue: '${this._settings.dleQueue}' asserted successfully`);

--- a/src/models/QWrapperSettings.ts
+++ b/src/models/QWrapperSettings.ts
@@ -10,5 +10,5 @@ export interface QWrapperSettings {
   reconnect?: boolean;
   prefetch?: number;
   dleQueue: string;
-  dleExchange: string;
+  dleExchange?: string;
 }

--- a/src/models/QWrapperSettings.ts
+++ b/src/models/QWrapperSettings.ts
@@ -3,11 +3,12 @@ import { ConnectionOptions } from './ConnectionOptions';
 export interface QWrapperSettings {
   connection: string | ConnectionOptions;
   queue: string;
-  dleQueue: string;
   exchange: string;
   exchangeType: string;
   verboseLogging?: boolean;
   veryVerboseLogging?: boolean;
   reconnect?: boolean;
   prefetch?: number;
+  dleQueue: string;
+  dleExchange: string;
 }


### PR DESCRIPTION
**Not a breaking change anymore - has fallback for the old behaviour now.**

Up until now the q-wrapper was filling up the DLE queue with a list of successful messages when using the FANOUT exchange type. This was happening because the DLE queue uses the same exchange as the regular FANOUT queue.

To fix this issue a new option called `dleExchange` is added to the q-wrapper settings and the code is adjusted to respect this option when creating the DLE exchange and the DLE queue.

**Example using the same exchange for DLE (old behaviour):**

```js
const qwrapperConfig = {
  // ...
  exchangeType: 'fanout',
  exchange: 'myexchange'
};

const qwrapper = new QWrapperDomain(qwrapperConfig);
// ...
```

**(Pseudo-code) Result when using the q-wrapper this way:**
```js
if (msg.processsed === true) {
   dleQueueMessagesCount += 1;
}
else if (msg.processed === false) {
   dleQueueMessagesCount += 2;
}
```

**Example using different exchange for DLE:**
```js
const qwrapperConfig = {
  // ...
  exchangeType: 'fanout',
  exchange: 'myexchange',
  dleExchange 'dle.myexchange'
};

const qwrapper = new QWrapperDomain(qwrapperConfig);
// ...
```

**(Pseudo-code) Result when using different exchange for DLE messages:**
```js
if (msg.processsed === true) {
   dleQueueMessagesCount += 0;
}
else if (msg.processed === false) {
   dleQueueMessagesCount += 1;
}

